### PR TITLE
project_timeline: unset `date_end` more safely

### DIFF
--- a/project_timeline/models/project_task.py
+++ b/project_timeline/models/project_task.py
@@ -21,5 +21,5 @@ class ProjectTask(models.Model):
 
     def update_date_end(self, stage_id):
         res = super(ProjectTask, self).update_date_end(stage_id)
-        res.pop('date_end')
+        res.pop('date_end', None)
         return res


### PR DESCRIPTION
We have a case where another addon removes `date_end` in `update_date_end()`, and when `update_date_end` from `project_timeline` is called it results in a `KeyError`. This makes the removal safer.